### PR TITLE
[M2-02] feat: Add court feats for user, vendor and admin

### DIFF
--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/config/SecurityConfig.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(req -> req
                         .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/media/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/venues", "/api/v1/venues/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/v1/venues/{venueId}/courts", "/api/v1/courts/{courtId}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/venues/*/courts", "/api/v1/courts/*").permitAll()
                         .requestMatchers("/api/v1/admin/**").hasAuthority(Role.ADMIN.name())
                         .anyRequest().authenticated()
                 )

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/config/SecurityConfig.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(req -> req
                         .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/media/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/venues", "/api/v1/venues/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/venues/{venueId}/courts", "/api/v1/courts/{courtId}").permitAll()
                         .requestMatchers("/api/v1/admin/**").hasAuthority(Role.ADMIN.name())
                         .anyRequest().authenticated()
                 )

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/controller/CourtController.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/controller/CourtController.java
@@ -39,7 +39,7 @@ class CourtController {
     public ApiResponse<Void> restoreCourt(@PathVariable Long courtId, @AuthenticationPrincipal User currentUser) {
         courtService.activateCourt(courtId, currentUser);
 
-        return ApiResponse.success(null, "Court restored successfully");
+        return ApiResponse.success(null, "Court activated successfully");
     }
 
     @GetMapping("/{courtId}")

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/controller/CourtController.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/controller/CourtController.java
@@ -1,0 +1,51 @@
+package com.dqhieuse.sportbookingbackend.modules.venue.controller;
+
+import com.dqhieuse.sportbookingbackend.common.dto.ApiResponse;
+import com.dqhieuse.sportbookingbackend.modules.auth.entity.User;
+import com.dqhieuse.sportbookingbackend.modules.venue.dto.CourtDetailResponse;
+import com.dqhieuse.sportbookingbackend.modules.venue.dto.UpdateCourtRequest;
+import com.dqhieuse.sportbookingbackend.modules.venue.service.CourtService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/courts")
+@RequiredArgsConstructor
+class CourtController {
+
+    private final CourtService courtService;
+
+    @PutMapping("/{courtId}")
+    public ApiResponse<CourtDetailResponse> updateCourt(
+            @PathVariable Long courtId,
+            @Valid @RequestBody UpdateCourtRequest request,
+            @AuthenticationPrincipal User currentUser
+    ) {
+        CourtDetailResponse updatedCourt = courtService.updateCourt(courtId, request, currentUser);
+
+        return ApiResponse.success(updatedCourt, "Court updated successfully");
+    }
+
+    @PostMapping("/{courtId}/inactive")
+    public ApiResponse<Void> inActiveCourt(@PathVariable Long courtId, @AuthenticationPrincipal User currentUser) {
+        courtService.inActiveCourt(courtId, currentUser);
+
+        return ApiResponse.success(null, "Court inactivated successfully");
+    }
+
+    @PostMapping("/{courtId}/active")
+    public ApiResponse<Void> restoreCourt(@PathVariable Long courtId, @AuthenticationPrincipal User currentUser) {
+        courtService.activeCourt(courtId, currentUser);
+
+        return ApiResponse.success(null, "Court restored successfully");
+    }
+
+    @GetMapping("/{courtId}")
+    public ApiResponse<CourtDetailResponse> getCourtDetail(@PathVariable Long courtId) {
+        CourtDetailResponse courtDetailResponse = courtService.findCourtById(courtId);
+
+        return ApiResponse.success(courtDetailResponse, "Court detail retrieved successfully");
+    }
+}

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/controller/CourtController.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/controller/CourtController.java
@@ -30,14 +30,14 @@ class CourtController {
 
     @PostMapping("/{courtId}/inactive")
     public ApiResponse<Void> inActiveCourt(@PathVariable Long courtId, @AuthenticationPrincipal User currentUser) {
-        courtService.inActiveCourt(courtId, currentUser);
+        courtService.inActivateCourt(courtId, currentUser);
 
         return ApiResponse.success(null, "Court inactivated successfully");
     }
 
     @PostMapping("/{courtId}/active")
     public ApiResponse<Void> restoreCourt(@PathVariable Long courtId, @AuthenticationPrincipal User currentUser) {
-        courtService.activeCourt(courtId, currentUser);
+        courtService.activateCourt(courtId, currentUser);
 
         return ApiResponse.success(null, "Court restored successfully");
     }

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/controller/VenueController.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/controller/VenueController.java
@@ -4,6 +4,7 @@ import com.dqhieuse.sportbookingbackend.common.dto.ApiResponse;
 import com.dqhieuse.sportbookingbackend.common.dto.PageResponse;
 import com.dqhieuse.sportbookingbackend.modules.auth.entity.User;
 import com.dqhieuse.sportbookingbackend.modules.venue.dto.*;
+import com.dqhieuse.sportbookingbackend.modules.venue.entity.Court;
 import com.dqhieuse.sportbookingbackend.modules.venue.service.VenueService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -104,5 +105,43 @@ class VenueController {
         venueService.softDeleteVenue(id, currentUser);
 
         return ApiResponse.success(null, "Venue deleted successfully", HttpStatus.NO_CONTENT);
+    }
+
+    @PostMapping("/{venueId}/courts")
+    public ApiResponse<CourtResponse> createCourt(
+            @PathVariable Long venueId,
+            @Valid @RequestBody CreateCourtRequest request,
+            @AuthenticationPrincipal User currentUser
+    ) {
+        CourtResponse createdCourt = venueService.createCourt(venueId, request, currentUser);
+
+        return ApiResponse.created(createdCourt, "Court created successfully");
+    }
+
+    @GetMapping("/{venueId}/my-courts")
+    public ApiResponse<PageResponse<CourtResponse>> getAllCourts(
+            @PathVariable Long venueId,
+            @PageableDefault(
+                    sort = {"createdAt"},
+                    direction = Sort.Direction.DESC
+            ) Pageable pageable,
+            @AuthenticationPrincipal User currentUser
+    ) {
+        PageResponse<CourtResponse> courts = venueService.findAllCourtForOwner(venueId, pageable, currentUser);
+
+        return ApiResponse.success(courts, "Fetched all courts successfully");
+    }
+
+    @GetMapping("/{venueId}/courts")
+    public ApiResponse<PageResponse<CourtResponse>> getAllActiveCourts(
+            @PathVariable Long venueId,
+            @PageableDefault(
+                    sort = {"createdAt"},
+                    direction = Sort.Direction.DESC
+            ) Pageable pageable
+    ) {
+        PageResponse<CourtResponse> courts = venueService.findAllActiveCourt(venueId, pageable);
+
+        return ApiResponse.success(courts, "Fetched all active courts successfully");
     }
 }

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/CourtDetailResponse.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/CourtDetailResponse.java
@@ -1,0 +1,13 @@
+package com.dqhieuse.sportbookingbackend.modules.venue.dto;
+
+import java.util.List;
+
+public record CourtDetailResponse(
+        CourtResponse court,
+        OwnerResponse owner,
+        String status,
+        String description,
+        String thumbnail,
+        List<CourtImageResponse> images
+) {
+}

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/CourtImageResponse.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/CourtImageResponse.java
@@ -1,0 +1,7 @@
+package com.dqhieuse.sportbookingbackend.modules.venue.dto;
+
+public record CourtImageResponse(
+        Long id,
+        String imageUrl
+) {
+}

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/CourtResponse.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/CourtResponse.java
@@ -9,6 +9,7 @@ public record CourtResponse(
         BigDecimal pricePerHour,
         Integer capacity,
         String thumbnail,
-        String status
+        String status,
+        Boolean active
 ) {
 }

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/CreateCourtRequest.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/CreateCourtRequest.java
@@ -21,7 +21,7 @@ public record CreateCourtRequest(
         BigDecimal pricePerHour,
 
         @NotNull(message = "Capacity is required")
-        @Min(value = 1, message = "Capacity must be greater than 0")
+        @Min(value = 1, message = "Capacity must be at least 1")
         Integer capacity,
 
         @NotBlank(message = "Thumbnail URL is required")

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/CreateCourtRequest.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/CreateCourtRequest.java
@@ -27,9 +27,6 @@ public record CreateCourtRequest(
         @NotBlank(message = "Thumbnail URL is required")
         String thumbnail,
 
-        @NotNull(message = "Active is required")
-        Boolean active,
-
         List<String> images,
 
         @Length(max = 1000, message = "Description must be less than 1000 characters")

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/CreateCourtRequest.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/CreateCourtRequest.java
@@ -1,0 +1,38 @@
+package com.dqhieuse.sportbookingbackend.modules.venue.dto;
+
+import com.dqhieuse.sportbookingbackend.modules.venue.entity.CourtType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record CreateCourtRequest(
+        @NotBlank(message = "Court name is required")
+        String name,
+
+        @NotNull(message = "Court type is required")
+        CourtType type,
+
+        @NotNull(message = "Price per hour is required")
+        @Min(value = 0, message = "Price must be greater than 0")
+        BigDecimal pricePerHour,
+
+        @NotNull(message = "Capacity is required")
+        @Min(value = 1, message = "Capacity must be greater than 0")
+        Integer capacity,
+
+        @NotBlank(message = "Thumbnail URL is required")
+        String thumbnail,
+
+        @NotNull(message = "Active is required")
+        Boolean active,
+
+        List<String> images,
+
+        @Length(max = 1000, message = "Description must be less than 1000 characters")
+        String description
+) {
+}

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/UpdateCourtRequest.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/dto/UpdateCourtRequest.java
@@ -1,0 +1,34 @@
+package com.dqhieuse.sportbookingbackend.modules.venue.dto;
+
+import com.dqhieuse.sportbookingbackend.modules.venue.entity.CourtType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+
+import java.math.BigDecimal;
+
+public record UpdateCourtRequest(
+        @NotBlank(message = "Court name is required.")
+        String name,
+
+        @Length(max = 1000, message = "Description must be less than 1000 characters.")
+        String description,
+
+        @NotNull(message = "Court type is required.")
+        CourtType type,
+
+        @NotNull(message = "Price per hour is required.")
+        @Min(value = 0, message = "Price must be non-negative.")
+        BigDecimal pricePerHour,
+
+        @NotNull(message = "Capacity is required.")
+        @Min(value = 1, message = "Capacity must be at least 1.")
+        Integer capacity,
+
+        @NotBlank(message = "Thumbnail URL is required.")
+        String thumbnail,
+
+        String images
+) {
+}

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/entity/Court.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/entity/Court.java
@@ -54,6 +54,9 @@ public class Court {
     @Column(name = "active", nullable = false)
     private Boolean active = true;
 
+    @Column(name = "description", length = 1000)
+    private String description;
+
     @ManyToOne
     @JoinColumn(name = "created_by", nullable = false)
     private User user;

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/entity/CourtStatus.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/entity/CourtStatus.java
@@ -1,6 +1,7 @@
 package com.dqhieuse.sportbookingbackend.modules.venue.entity;
 
 public enum CourtStatus {
+    PENDING,
     AVAILABLE,
     BOOKED
 }

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/mapper/VenueMapper.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/mapper/VenueMapper.java
@@ -46,5 +46,32 @@ public interface VenueMapper {
 
     CourtResponse toCourtResponse(Court court);
 
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "venue", ignore = true),
+            @Mapping(target = "status", ignore = true),
+            @Mapping(target = "version", ignore = true),
+            @Mapping(target = "user", ignore = true),
+            @Mapping(target = "createdAt", ignore = true),
+            @Mapping(target = "updatedAt", ignore = true)
+    })
+    Court toCourtEntity(CreateCourtRequest createCourtRequest);
+
+    List<CourtResponse> toCourtResponseList(List<Court> courts);
+
+    CourtDetailResponse toCourtDetailResponse(Court court);
+
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(target = "venue", ignore = true),
+            @Mapping(target = "status", ignore = true),
+            @Mapping(target = "active", ignore = true),
+            @Mapping(target = "version", ignore = true),
+            @Mapping(target = "user", ignore = true),
+            @Mapping(target = "createdAt", ignore = true),
+            @Mapping(target = "updatedAt", ignore = true)
+    })
+    void updateCourtFromRequest(UpdateCourtRequest request, @MappingTarget Court court);
+
     VenueImageResponse toImageResponse(VenueImage venueImage);
 }

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/repository/CourtRepository.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/repository/CourtRepository.java
@@ -1,9 +1,19 @@
 package com.dqhieuse.sportbookingbackend.modules.venue.repository;
 
+import com.dqhieuse.sportbookingbackend.modules.auth.entity.User;
 import com.dqhieuse.sportbookingbackend.modules.venue.entity.Court;
+import com.dqhieuse.sportbookingbackend.modules.venue.entity.CourtStatus;
+import com.dqhieuse.sportbookingbackend.modules.venue.entity.Venue;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+
 @Repository
 public interface CourtRepository extends JpaRepository<Court, Long> {
+    Page<Court> findAllByUserAndVenue(User user, Venue venue, Pageable pageable);
+
+    Page<Court> findAllByVenueAndActiveAndStatusIn(Venue venue, Boolean active, Collection<CourtStatus> statuses, Pageable pageable);
 }

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/service/CourtService.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/service/CourtService.java
@@ -50,7 +50,7 @@ public class CourtService {
     }
 
     @Transactional
-    public void inActiveCourt(Long courtId, User currentUser) {
+    public void inActivateCourt(Long courtId, User currentUser) {
         Court court = courtRepository.findById(courtId).orElseThrow(
                 () -> new AppException(HttpStatus.NOT_FOUND, "Court not found with id: " + courtId)
         );
@@ -76,7 +76,7 @@ public class CourtService {
     }
 
     @Transactional
-    public void activeCourt(Long courtId, User currentUser) {
+    public void activateCourt(Long courtId, User currentUser) {
         Court court = courtRepository.findById(courtId).orElseThrow(
                 () -> new AppException(HttpStatus.NOT_FOUND, "Court not found with id: " + courtId)
         );

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/service/CourtService.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/service/CourtService.java
@@ -32,11 +32,7 @@ public class CourtService {
 
         Venue venue = court.getVenue();
 
-        boolean isVendor = currentUser.getRole() == Role.VENDOR;
-        boolean isCourtOwner = court.getUser().getId().equals(currentUser.getId());
-        boolean isVenueOwner = venue.getOwner().getId().equals(currentUser.getId());
-
-        boolean hasPermission = (isCourtOwner || isVenueOwner) && isVendor;
+        boolean hasPermission = isHasPermission(currentUser, court, venue);
 
         if (!hasPermission) {
             throw new AppException(HttpStatus.NOT_ACCEPTABLE, "You are not authorized to update court");
@@ -57,11 +53,7 @@ public class CourtService {
 
         Venue venue = court.getVenue();
 
-        boolean isVendor = currentUser.getRole() == Role.VENDOR;
-        boolean isCourtOwner = court.getUser().getId().equals(currentUser.getId());
-        boolean isVenueOwner = venue.getOwner().getId().equals(currentUser.getId());
-
-        boolean hasPermission = (isCourtOwner || isVenueOwner) && isVendor;
+        boolean hasPermission = isHasPermission(currentUser, court, venue);
 
         if (!hasPermission) {
             throw new AppException(HttpStatus.NOT_ACCEPTABLE, "You are not authorized to inActive court");
@@ -75,6 +67,15 @@ public class CourtService {
         courtRepository.save(court);
     }
 
+    private static boolean isHasPermission(User currentUser, Court court, Venue venue) {
+        boolean isVendor = currentUser.getRole() == Role.VENDOR;
+        boolean isCourtOwner = court.getUser().getId().equals(currentUser.getId());
+        boolean isVenueOwner = venue.getOwner().getId().equals(currentUser.getId());
+
+        boolean hasPermission = (isCourtOwner || isVenueOwner) && isVendor;
+        return hasPermission;
+    }
+
     @Transactional
     public void activateCourt(Long courtId, User currentUser) {
         Court court = courtRepository.findById(courtId).orElseThrow(
@@ -83,11 +84,7 @@ public class CourtService {
 
         Venue venue = court.getVenue();
 
-        boolean isVendor = currentUser.getRole() == Role.VENDOR;
-        boolean isCourtOwner = court.getUser().getId().equals(currentUser.getId());
-        boolean isVenueOwner = venue.getOwner().getId().equals(currentUser.getId());
-
-        boolean hasPermission = (isCourtOwner || isVenueOwner) && isVendor;
+        boolean hasPermission = isHasPermission(currentUser, court, venue);
 
         if (!hasPermission) {
             throw new AppException(HttpStatus.NOT_ACCEPTABLE, "You are not authorized to active court");

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/service/CourtService.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/service/CourtService.java
@@ -1,0 +1,117 @@
+package com.dqhieuse.sportbookingbackend.modules.venue.service;
+
+import com.dqhieuse.sportbookingbackend.common.exception.AppException;
+import com.dqhieuse.sportbookingbackend.modules.auth.entity.Role;
+import com.dqhieuse.sportbookingbackend.modules.auth.entity.User;
+import com.dqhieuse.sportbookingbackend.modules.venue.dto.CourtDetailResponse;
+import com.dqhieuse.sportbookingbackend.modules.venue.dto.UpdateCourtRequest;
+import com.dqhieuse.sportbookingbackend.modules.venue.entity.Court;
+import com.dqhieuse.sportbookingbackend.modules.venue.entity.CourtStatus;
+import com.dqhieuse.sportbookingbackend.modules.venue.entity.Venue;
+import com.dqhieuse.sportbookingbackend.modules.venue.mapper.VenueMapper;
+import com.dqhieuse.sportbookingbackend.modules.venue.repository.CourtRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CourtService {
+
+    private final CourtRepository courtRepository;
+    private final VenueMapper venueMapper;
+
+    @Transactional
+    public CourtDetailResponse updateCourt(Long courtId, UpdateCourtRequest request, User currentUser) {
+        Court court = courtRepository.findById(courtId).orElseThrow(
+                () -> new AppException(HttpStatus.NOT_FOUND, "Court not found with id: " + courtId)
+        );
+
+        Venue venue = court.getVenue();
+
+        boolean isVendor = currentUser.getRole() == Role.VENDOR;
+        boolean isCourtOwner = court.getUser().getId().equals(currentUser.getId());
+        boolean isVenueOwner = venue.getOwner().getId().equals(currentUser.getId());
+
+        boolean hasPermission = (isCourtOwner || isVenueOwner) && isVendor;
+
+        if (!hasPermission) {
+            throw new AppException(HttpStatus.NOT_ACCEPTABLE, "You are not authorized to update court");
+        }
+
+        venueMapper.updateCourtFromRequest(request, court);
+
+        Court updatedCourt = courtRepository.save(court);
+
+        return venueMapper.toCourtDetailResponse(updatedCourt);
+    }
+
+    @Transactional
+    public void inActiveCourt(Long courtId, User currentUser) {
+        Court court = courtRepository.findById(courtId).orElseThrow(
+                () -> new AppException(HttpStatus.NOT_FOUND, "Court not found with id: " + courtId)
+        );
+
+        Venue venue = court.getVenue();
+
+        boolean isVendor = currentUser.getRole() == Role.VENDOR;
+        boolean isCourtOwner = court.getUser().getId().equals(currentUser.getId());
+        boolean isVenueOwner = venue.getOwner().getId().equals(currentUser.getId());
+
+        boolean hasPermission = (isCourtOwner || isVenueOwner) && isVendor;
+
+        if (!hasPermission) {
+            throw new AppException(HttpStatus.NOT_ACCEPTABLE, "You are not authorized to inActive court");
+        }
+
+        if (!court.getActive()) {
+            throw new AppException(HttpStatus.NOT_ACCEPTABLE, "Court is already inactive");
+        }
+
+        court.setActive(false);
+        courtRepository.save(court);
+    }
+
+    @Transactional
+    public void activeCourt(Long courtId, User currentUser) {
+        Court court = courtRepository.findById(courtId).orElseThrow(
+                () -> new AppException(HttpStatus.NOT_FOUND, "Court not found with id: " + courtId)
+        );
+
+        Venue venue = court.getVenue();
+
+        boolean isVendor = currentUser.getRole() == Role.VENDOR;
+        boolean isCourtOwner = court.getUser().getId().equals(currentUser.getId());
+        boolean isVenueOwner = venue.getOwner().getId().equals(currentUser.getId());
+
+        boolean hasPermission = (isCourtOwner || isVenueOwner) && isVendor;
+
+        if (!hasPermission) {
+            throw new AppException(HttpStatus.NOT_ACCEPTABLE, "You are not authorized to active court");
+        }
+
+        if (court.getActive()) {
+            throw new AppException(HttpStatus.NOT_ACCEPTABLE, "Court is already active");
+        }
+
+        court.setActive(true);
+        courtRepository.save(court);
+    }
+
+    public CourtDetailResponse findCourtById(Long courtId) {
+        Court court = courtRepository.findById(courtId).orElseThrow(
+                () -> new AppException(HttpStatus.NOT_FOUND, "Court not found with id: " + courtId)
+        );
+
+        List<CourtStatus> allowedStatuses = List.of(CourtStatus.BOOKED, CourtStatus.AVAILABLE);
+
+        if (!court.getActive() || court.getVenue().isDeleted() || !allowedStatuses.contains(court.getStatus())) {
+            throw new AppException(HttpStatus.NOT_FOUND, "Court is not active or deleted");
+        }
+
+        return venueMapper.toCourtDetailResponse(court);
+    }
+}

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/service/VenueService.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/service/VenueService.java
@@ -399,6 +399,7 @@ public class VenueService {
         venue.addCourt(court);
         court.setUser(currentUser);
         court.setStatus(CourtStatus.PENDING);
+        court.setActive(true);
 
         Court courtAdded = courtRepository.save(court);
 

--- a/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/service/VenueService.java
+++ b/sport-booking-backend/src/main/java/com/dqhieuse/sportbookingbackend/modules/venue/service/VenueService.java
@@ -7,10 +7,9 @@ import com.dqhieuse.sportbookingbackend.modules.auth.entity.Role;
 import com.dqhieuse.sportbookingbackend.modules.auth.entity.User;
 import com.dqhieuse.sportbookingbackend.modules.fileupload.service.FileUploadService;
 import com.dqhieuse.sportbookingbackend.modules.venue.dto.*;
-import com.dqhieuse.sportbookingbackend.modules.venue.entity.Venue;
-import com.dqhieuse.sportbookingbackend.modules.venue.entity.VenueImage;
-import com.dqhieuse.sportbookingbackend.modules.venue.entity.VenueStatus;
+import com.dqhieuse.sportbookingbackend.modules.venue.entity.*;
 import com.dqhieuse.sportbookingbackend.modules.venue.mapper.VenueMapper;
+import com.dqhieuse.sportbookingbackend.modules.venue.repository.CourtRepository;
 import com.dqhieuse.sportbookingbackend.modules.venue.repository.VenueImageRepository;
 import com.dqhieuse.sportbookingbackend.modules.venue.repository.VenueRepository;
 import jakarta.persistence.EntityManager;
@@ -35,6 +34,7 @@ public class VenueService {
     private final VenueImageRepository venueImageRepository;
     private final FileUploadService fileUploadService;
     private final EntityManager entityManager;
+    private final CourtRepository courtRepository;
 
     @Transactional
     public VenueDetailResponse createVenue(CreateVenueRequest request, User currentUser) {
@@ -379,5 +379,86 @@ public class VenueService {
 
         venue.setStatus(VenueStatus.ACTIVE);
         venueRepository.save(venue);
+    }
+
+    @Transactional
+    public CourtResponse createCourt(Long venueId, CreateCourtRequest request, User currentUser) {
+        Venue venue = venueRepository.findById(venueId).orElseThrow(
+                () -> new AppException(HttpStatus.NOT_FOUND, "Venue not found with id: " + venueId)
+        );
+
+        boolean hasPermission = venue.getOwner().getId().equals(currentUser.getId()) &&
+                (currentUser.getRole() == Role.VENDOR || currentUser.getRole() == Role.ADMIN);
+
+        if (!hasPermission) {
+            throw new AppException(HttpStatus.NOT_ACCEPTABLE, "You are not authorized to create court");
+        }
+
+        Court court = venueMapper.toCourtEntity(request);
+
+        venue.addCourt(court);
+        court.setUser(currentUser);
+        court.setStatus(CourtStatus.PENDING);
+
+        Court courtAdded = courtRepository.save(court);
+
+        return venueMapper.toCourtResponse(courtAdded);
+    }
+
+    public PageResponse<CourtResponse> findAllCourtForOwner(Long venueId, Pageable pageable, User currentUser) {
+        Venue venue = venueRepository.findById(venueId).orElseThrow(
+                () -> new AppException(HttpStatus.NOT_FOUND, "Venue not found with id: " + venueId)
+        );
+
+        boolean hasPermission = venue.getOwner().getId().equals(currentUser.getId()) &&
+                (currentUser.getRole() == Role.VENDOR);
+
+        if (!hasPermission) {
+            throw new AppException(HttpStatus.NOT_ACCEPTABLE, "You are not authorized to view courts");
+        }
+
+        Page<Court> courts = courtRepository.findAllByUserAndVenue(currentUser, venue, pageable);
+
+        List<CourtResponse> courtResponses = venueMapper.toCourtResponseList(courts.getContent());
+
+        MetaResponse meta = MetaResponse.builder()
+                .pageNo(pageable.getPageNumber())
+                .pageSize(pageable.getPageSize())
+                .totalElements(courts.getTotalElements())
+                .totalPages(courts.getTotalPages())
+                .build();
+
+        return PageResponse.<CourtResponse>builder()
+                .content(courtResponses)
+                .meta(meta)
+                .build();
+    }
+
+    public PageResponse<CourtResponse> findAllActiveCourt(Long venueId, Pageable pageable) {
+        Venue venue = venueRepository.findById(venueId).orElseThrow(
+                () -> new AppException(HttpStatus.NOT_FOUND, "Venue not found with id: " + venueId)
+        );
+
+        if (venue.getStatus() != VenueStatus.ACTIVE || venue.isDeleted()) {
+            throw new AppException(HttpStatus.NOT_FOUND, "Venue is not active or deleted");
+        }
+
+        List<CourtStatus> allowedStatuses = List.of(CourtStatus.BOOKED, CourtStatus.AVAILABLE);
+
+        Page<Court> courts = courtRepository.findAllByVenueAndActiveAndStatusIn(venue, true, allowedStatuses, pageable);
+
+        List<CourtResponse> courtResponses = venueMapper.toCourtResponseList(courts.getContent());
+
+        MetaResponse meta = MetaResponse.builder()
+                .pageNo(pageable.getPageNumber())
+                .pageSize(pageable.getPageSize())
+                .totalElements(courts.getTotalElements())
+                .totalPages(courts.getTotalPages())
+                .build();
+
+        return PageResponse.<CourtResponse>builder()
+                .content(courtResponses)
+                .meta(meta)
+                .build();
     }
 }


### PR DESCRIPTION
This pull request introduces comprehensive support for managing courts within venues, including creating, updating, activating/inactivating, and retrieving court details. It adds new endpoints, DTOs, service logic, and repository methods to enable these features, while also refining the security configuration to allow public access to relevant endpoints.

**Key changes:**

**API and Controller Enhancements:**
- Added `CourtController` with endpoints for updating court details, activating/inactivating courts, and retrieving court details by ID.
- Extended `VenueController` with endpoints for creating a court, retrieving all courts for a venue owner, and listing all active courts for a venue.

**DTOs and Entity Updates:**
- Introduced new DTOs: `CreateCourtRequest`, `UpdateCourtRequest`, `CourtDetailResponse`, and `CourtImageResponse` for request and response payloads related to courts. [[1]](diffhunk://#diff-fe04b02872224c88c37b3a4eae9e82b8ae2919cc094e80351c34eedaf756810fR1-R38) [[2]](diffhunk://#diff-2a8e689104505674238d6acd218bdf3088523f3b7248022aaca0189f9f92454cR1-R34) [[3]](diffhunk://#diff-bb708a21bb14e17743ab8bcc535ef642dc5cfa6975f71603eb04b64aa4a92855R1-R13) [[4]](diffhunk://#diff-5e351ffab81264a60e5ec3c14edbcca2c51a8434a3d3a3ff3e929e2729b1f518R1-R7)
- Updated `CourtResponse` to include an `active` field, and added a `description` field to the `Court` entity. [[1]](diffhunk://#diff-f24c26ea3f8e00a3d8285be04275fa019a3e4fd89e04b40f6c9bcc5922c088c6L12-R13) [[2]](diffhunk://#diff-f7f8bf4fa6599cd6fc65f77f9a43c80122f86f2c6dda93444863ab60d4350a14R57-R59)
- Added `PENDING` status to `CourtStatus` enum.

**Service and Repository Layer:**
- Added `CourtService` with business logic for updating, activating/inactivating, and retrieving courts with permission checks.
- Enhanced `CourtRepository` with methods to support filtering courts by user, venue, active status, and status.
- Injected `CourtRepository` into `VenueService` for court management. [[1]](diffhunk://#diff-985a26c43dd881bc165a69141cd634ff514514c5304aaec183e7f2dbddd6fd08L10-R12) [[2]](diffhunk://#diff-985a26c43dd881bc165a69141cd634ff514514c5304aaec183e7f2dbddd6fd08R37)

**Mapping and Security Configuration:**
- Expanded `VenueMapper` with mapping methods for new court DTOs and update logic.
- Updated security configuration to permit public GET access to court and venue endpoints.